### PR TITLE
Added `rom.path.exists()`

### DIFF
--- a/src/lua/bindings/path.cpp
+++ b/src/lua/bindings/path.cpp
@@ -193,6 +193,29 @@ namespace lua::path
 		return false;
 	}
 
+	// Lua API: Function
+	// Table: path
+	// Name: exists
+	// Param: path: string: The path to check.
+	// Returns: boolean: true if the path exists, false otherwise.
+	static bool exists(const std::string& path)
+	{
+		try
+		{
+			return std::filesystem::exists(path);
+		}
+		catch (const std::exception& e)
+		{
+			LOG(WARNING) << e.what();
+		}
+		catch (...)
+		{
+			LOG(WARNING) << "Unknown exception while checking existence of path " << path;
+		}
+	
+		return false;
+	}
+
 	void bind(sol::table& state)
 	{
 		auto ns = state.create_named("path");
@@ -204,5 +227,6 @@ namespace lua::path
 		ns["filename"]         = filename;
 		ns["stem"]             = stem;
 		ns["create_directory"] = create_directory;
+		ns["exists"]           = exists;
 	}
 } // namespace lua::path


### PR DESCRIPTION
Allows checking for the existence of a path from within the Hell2Modding ecosystem.

I'm not completely familiar with your project structure, so feel free to point out anything I might have missed to get this working. I believe the changes to Hell2Modding (documentation, cmake file) would need to be done manually after this is merged?