### PR TITLE
Add mod guid to missing_modules when skipped due to missing dependency

### DIFF
--- a/src/lua/lua_manager.hpp
+++ b/src/lua/lua_manager.hpp
@@ -282,7 +282,7 @@ namespace big
 					{
 						LOG(WARNING) << "Can't load " << guid << " because it's missing " << dependency;
 						not_missing_dependency = false;
-						missing_modules.insert(dependency);
+						missing_modules.insert(guid);
 					}
 				}
 

--- a/src/lua/lua_manager.hpp
+++ b/src/lua/lua_manager.hpp
@@ -282,6 +282,7 @@ namespace big
 					{
 						LOG(WARNING) << "Can't load " << guid << " because it's missing " << dependency;
 						not_missing_dependency = false;
+						missing_modules.insert(dependency);
 					}
 				}
 


### PR DESCRIPTION
ChaoticDreams depends on DreamDiveTweaks and DreamDiveTweaks depends on BoonOverflowFix. Tested by just disabling BoonOverflowFix

Before:

<img width="1304" height="238" alt="image" src="https://github.com/user-attachments/assets/d0c84ad7-a97c-418c-a71f-ebdcce38fe4d" />

After:

<img width="1317" height="263" alt="image" src="https://github.com/user-attachments/assets/53440649-ec76-4517-b0cf-6495971e2f68" />
