### PR TITLE
Add rom_soft_deps field

### DIFF
--- a/src/lua/lua_manager.cpp
+++ b/src/lua/lua_manager.cpp
@@ -81,6 +81,19 @@ namespace big
 			}
 		}
 
+		for (const auto& dep : manifest.rom_soft_deps)
+		{
+			const auto splitted = big::string::split(dep, '-');
+			if (splitted.size() == 3)
+			{
+				manifest.rom_soft_deps_no_version_number.push_back(splitted[0] + '-' + splitted[1]);
+			}
+			else
+			{
+				LOG(ERROR) << "Invalid soft dependency string " << dep << " inside the following manifest: " << manifest_path << ". Example format: AuthorName-ModName-1.0.0";
+			}
+		}
+
 		std::string folder_name = (char*)current_folder.filename().u8string().c_str();
 		const auto sep_count    = std::ranges::count(folder_name, '-');
 		if (sep_count != 1)

--- a/src/lua/lua_manager.hpp
+++ b/src/lua/lua_manager.hpp
@@ -251,7 +251,16 @@ namespace big
 			                                             {
 				                                             if (module_guid_to_module_info.contains(guid))
 				                                             {
-					                                             return module_guid_to_module_info[guid].m_manifest.dependencies_no_version_number;
+																std::vector<std::string> all_deps;
+																all_deps.insert(all_deps.end(),
+																	module_guid_to_module_info[guid].m_manifest.dependencies_no_version_number.begin(),
+																	module_guid_to_module_info[guid].m_manifest.dependencies_no_version_number.end()
+																);
+																all_deps.insert(all_deps.end(),
+																	module_guid_to_module_info[guid].m_manifest.rom_soft_deps_no_version_number.begin(),
+																	module_guid_to_module_info[guid].m_manifest.rom_soft_deps_no_version_number.end()
+																);
+																return all_deps;
 				                                             }
 				                                             return std::vector<std::string>();
 			                                             });

--- a/src/thunderstore/v1/manifest.hpp
+++ b/src/thunderstore/v1/manifest.hpp
@@ -26,6 +26,9 @@ namespace ts::v1
 		std::vector<std::string> dependencies{};
 		std::vector<std::string> dependencies_no_version_number{};
 
-		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(manifest, name, version_number, website_url, description, dependencies)
+		std::vector<std::string> rom_soft_deps{};
+		std::vector<std::string> rom_soft_deps_no_version_number{};
+
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(manifest, name, version_number, website_url, description, dependencies, rom_soft_deps)
 	};
 } // namespace ts::v1


### PR DESCRIPTION
Assume soft deps as required while getting the sort order, but their load failures don't affect any mods that are soft dependent on them.