### PR TITLE
Fix freed-memory crashes on Linux

### DIFF
--- a/src/directory_watcher/directory_watcher.cpp
+++ b/src/directory_watcher/directory_watcher.cpp
@@ -83,7 +83,15 @@ namespace big
 	{
 		if (_file_handle != INVALID_HANDLE_VALUE)
 		{
-			CancelIo(_file_handle);
+			// Reap the cancelled read before _overlapped and _buffer die, or the kernel writes STATUS_CANCELLED into freed memory and corrupts whatever reuses it
+			if (CancelIoEx(_file_handle, &_overlapped) || GetLastError() != ERROR_NOT_FOUND)
+			{
+				DWORD transferred         = 0;
+				ULONG_PTR key             = 0;
+				LPOVERLAPPED lpOverlapped = nullptr;
+				GetQueuedCompletionStatus(_completion_handle, &transferred, &key, &lpOverlapped, 1000);
+			}
+
 			CloseHandle(_file_handle);
 			LOG(INFO) << "File handle closed successfully.";
 		}

--- a/src/lua/bindings/path.cpp
+++ b/src/lua/bindings/path.cpp
@@ -6,6 +6,7 @@
 #include "threads/util.hpp"
 
 #include <filesystem>
+#include <deque>
 
 // clang-format off
 #include <AsyncLogger/Logger.hpp>
@@ -301,7 +302,7 @@ namespace lua::path
 			    {
 				    big::threads::g_rom_thread_ids.insert(GetCurrentThreadId());
 
-				    std::vector<big::directory_watcher> watchers;
+				    std::deque<big::directory_watcher> watchers;
 				    watchers.emplace_back(directory);
 				    for (const auto& entry : std::filesystem::recursive_directory_iterator(directory, std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink))
 				    {

--- a/src/lua/lua_manager.cpp
+++ b/src/lua/lua_manager.cpp
@@ -14,6 +14,8 @@
 #include "logger/logger.hpp"
 #include "string/string.hpp"
 
+#include <deque>
+
 namespace big
 {
 	std::optional<module_info> lua_manager::get_module_info(const std::filesystem::path& module_path)
@@ -167,7 +169,7 @@ namespace big
 		    {
 			    big::threads::g_rom_thread_ids.insert(GetCurrentThreadId());
 
-			    std::vector<big::directory_watcher> watchers;
+			    std::deque<big::directory_watcher> watchers;
 			    watchers.emplace_back(directory);
 			    for (const auto& entry : std::filesystem::recursive_directory_iterator(directory, std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink))
 			    {


### PR DESCRIPTION
Fixes random crashes on save load for Linux and Steam Deck players running Hades II through Proton or Wine, where the kernel's asynchronous I/O cancellation timing exposes the freed-memory bug that Windows almost always tolerates.